### PR TITLE
fix: print_nordvpn_status

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -8,14 +8,14 @@ connecting_text=$(get_tmux_option "@nordvpn_connecting_text" "Connecting")
 disconnected_text=$(get_tmux_option "@nordvpn_disconnected_text" "Disconnected")
 
 print_nordvpn_status() {
-    status=$(nordvpn status | grep 'Status:')
+    status=$(nordvpn status | grep 'Status:\s.*')
 
-    if [[ $status == "Disconnected" ]]; then
-        echo "$disconnected_text"
-    elif [[ $status == "Connecting" ]]; then
-        echo "$connecting_text"
-    elif [[ $status == "Connected" ]]; then
-        echo "$connected_text"
+    if [[ "$status" == *"Disconnected"* ]]; then
+      echo "$disconnected_text"
+    elif [[ "$status" == *"Connecting"* ]]; then
+      echo "$connecting_text"
+    elif [[ "$status" == *"Connected"* ]]; then
+      echo "$connected_text"
     fi
 }
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -8,7 +8,7 @@ connecting_text=$(get_tmux_option "@nordvpn_connecting_text" "Connecting")
 disconnected_text=$(get_tmux_option "@nordvpn_disconnected_text" "Disconnected")
 
 print_nordvpn_status() {
-    status=$(nordvpn status | sed -n -e 's/^Status: \(.*\)/\1/p')
+    status=$(nordvpn status | grep 'Status:')
 
     if [[ $status == "Disconnected" ]]; then
         echo "$disconnected_text"


### PR DESCRIPTION
instead of using `sed` to parse the output of `nordvpn status`, i pull the entire line containing the status with `grep "Status:\s.*"` and then check if that line contains the respective substring, by wrapping the substring with `*`. ie. `*"Connected"*`.